### PR TITLE
Fixed PHP warnings in Object Cache classes

### DIFF
--- a/memcache.tpl
+++ b/memcache.tpl
@@ -362,7 +362,7 @@ class WP_Object_Cache {
 		}
 	}
 
-	function WP_Object_Cache() {
+	function __construct() {
 
 		$memcached_servers = array(
 				'default' => array(

--- a/memcache.tpl
+++ b/memcache.tpl
@@ -98,7 +98,12 @@ class WP_Object_Cache {
 
 	var $cache = array();
 	var $mc = array();
-	var $stats = array();
+	var $stats = array(
+		'add'       => 0,
+		'delete'    => 0,
+		'get'       => 0,
+		'get_multi' => 0,
+	);
 	var $group_ops = array();
 
 	var $cache_enabled = true;

--- a/memcached.tpl
+++ b/memcached.tpl
@@ -122,7 +122,12 @@ class WP_Object_Cache {
 
 	var $cache = array();
 	var $mc = array();
-	var $stats = array();
+	var $stats = array(
+		'add'       => 0,
+		'delete'    => 0,
+		'get'       => 0,
+		'get_multi' => 0,
+	);
 	var $group_ops = array();
 
 	var $cache_enabled = true;

--- a/memcached.tpl
+++ b/memcached.tpl
@@ -412,7 +412,7 @@ class WP_Object_Cache {
 		return $this->mc['default'];
 	}
 
-	function WP_Object_Cache() {
+	function __construct() {
 		
 		$memcached_servers = array(
 					'default' => array(


### PR DESCRIPTION
 - class name styles constructors are deprecated in PHP 7
 - incrementing unset stats was caught as error by custom handlers (such as Query Monitor)