### PR TITLE
fix to memcache templates

### DIFF
--- a/memcache.tpl
+++ b/memcache.tpl
@@ -274,6 +274,9 @@ class WP_Object_Cache {
 		else
 			$prefix = $this->blog_prefix;
 
+		if ( defined( 'ICL_LANGUAGE_CODE' ) )
+			$prefix .= ICL_LANGUAGE_CODE . ':';
+
 		return preg_replace('/\s+/', '', substr(md5(dirname(__FILE__)),7) . "$prefix$group:$key");
 	}
 

--- a/memcached.tpl
+++ b/memcached.tpl
@@ -308,6 +308,9 @@ class WP_Object_Cache {
 		else
 			$prefix = $this->blog_prefix;
 
+		if ( defined( 'ICL_LANGUAGE_CODE' ) )
+			$prefix .= ICL_LANGUAGE_CODE . ':';
+
 		return preg_replace( '/\s+/', '', substr(md5(dirname(__FILE__)),7) . "$prefix$group:$key" );
 	}
 


### PR DESCRIPTION
This enables the support to WPML and avoid to show contents in different languages into pages. For instance: without this hack, your implementation returns next/prev-post permalinks in wrong language after the first load of a page. Also, check this up:  https://github.com/tszming/apc-object-cache/commit/47c79c5b463b4d17ce9d4f610cc804789ea13dd9