### PR TITLE
Fixes login issues when used with WPML

### DIFF
--- a/memcache.tpl
+++ b/memcache.tpl
@@ -274,7 +274,7 @@ class WP_Object_Cache {
 		else
 			$prefix = $this->blog_prefix;
 
-		if ( defined( 'ICL_LANGUAGE_CODE' ) )
+		if ( ! in_array( $group, $this->global_groups ) && defined( 'ICL_LANGUAGE_CODE' ) )
 			$prefix .= ICL_LANGUAGE_CODE . ':';
 
 		return preg_replace('/\s+/', '', substr(md5(dirname(__FILE__)),7) . "$prefix$group:$key");

--- a/memcached.tpl
+++ b/memcached.tpl
@@ -308,7 +308,7 @@ class WP_Object_Cache {
 		else
 			$prefix = $this->blog_prefix;
 
-		if ( defined( 'ICL_LANGUAGE_CODE' ) )
+		if ( ! in_array( $group, $this->global_groups ) && defined( 'ICL_LANGUAGE_CODE' ) )
 			$prefix .= ICL_LANGUAGE_CODE . ':';
 
 		return preg_replace( '/\s+/', '', substr(md5(dirname(__FILE__)),7) . "$prefix$group:$key" );


### PR DESCRIPTION
We have had several reports about this in the WPML support forum:

https://wpml.org/it/forums/topic/problema-compatibilia-php7-siteground-memcached-wpml/
https://wpml.org/it/forums/topic/se-attivo-wpml-non-riesco-ad-accedere-al-backend-di-wordpress/
https://wpml.org/forums/topic/preoccupante-mail-da-aruba-riguardo-alluso-delle-risorse-di-wpml/#post-1537626
https://wpml.org/forums/topic/not-enough-permissions-to-access-my-dashboard-when-wpml-is-enabled/

The problem has to do with adding a language prefix to users and usermeta cache groups.
A solution for this can be not to add the language prefix for global groups.

In my tests with memcached it worked fine in a variety of different situations.
Unfortunately I haven't been able to test it with memcache but I suspect the same will apply.