### PR TITLE
Fixed Force HTTPs in multisite context

### DIFF
--- a/class-sg-cachepress-multisite.php
+++ b/class-sg-cachepress-multisite.php
@@ -26,6 +26,8 @@ class SG_CachePress_Multisite {
 			return;
 		}
 
+        $this->force_https();
+
 		if ( is_network_admin() ) {
 
 		    // TODO change log to DI to simplify tests. R.
@@ -77,6 +79,25 @@ class SG_CachePress_Multisite {
 			$this->log = new SG_CachePress_Log();
 			add_action( 'wp_ajax_sg-purge-cache', [ $this, 'wp_ajax' ] );
 		}
+	}
+
+	/**
+	 * Force HTTPs in multisite context, which does not use htaccess redirects.
+	 */
+	public function force_https() {
+
+		$force  = ( '1' === get_option( 'sg_cachepress_ssl_enabled' ) );
+		$scheme = $_SERVER['REQUEST_SCHEME'];
+		$method = $_SERVER['REQUEST_METHOD'];
+
+		if ( ! $force || 'http' !== $scheme || 'GET' !== $method ) {
+			return;
+		}
+
+		$redirect = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+
+		wp_safe_redirect( $redirect );
+		die;
 	}
 
 	/**

--- a/class-sg-cachepress-ssl.php
+++ b/class-sg-cachepress-ssl.php
@@ -186,8 +186,8 @@ class SG_CachePress_SSL
      */
     public static function disable_from_htaccess()
     {
-	    if ( is_multisite() ) {
-		    return false;
+	    if ( is_multisite() ) { // MS doesn’t use htaccess, but this is also being used as turn off success check. R.
+		    return true;
 	    }
 
         $filename = self::get_htaccess_filename(false);


### PR DESCRIPTION
Spent some time looking if there is a way to better untangle multisite logic in settings, but would need to rewrite a lot. Scaled back to a straightforward fix in a check for the saving bug.

Redirect implementation is a balancing act between performance (loading WP is heavy by itself), being reasonably useful, and not breaking things (such as form submissions). Might need some fine tuning.

Fixes https://github.com/Rarst/sg-cachepress/issues/38