### PR TITLE
Adjusted how SSL is checked for in force redirect for multisite

### DIFF
--- a/class-sg-cachepress-multisite.php
+++ b/class-sg-cachepress-multisite.php
@@ -87,10 +87,9 @@ class SG_CachePress_Multisite {
 	public function force_https() {
 
 		$force  = ( '1' === get_option( 'sg_cachepress_ssl_enabled' ) );
-		$scheme = $_SERVER['REQUEST_SCHEME'];
 		$method = $_SERVER['REQUEST_METHOD'];
 
-		if ( ! $force || 'http' !== $scheme || 'GET' !== $method ) {
+		if ( ! $force || 'GET' !== $method || is_ssl() ) {
 			return;
 		}
 


### PR DESCRIPTION
Changed to `is_ssl()` core's function, which wraps `HTTPS` & `SERVER_PORT` checks.

Fixes https://github.com/Rarst/sg-cachepress/issues/39